### PR TITLE
Fix stem refs not being remapped when duplicating a scenario

### DIFF
--- a/backend/modules/scenarios/services/duplicateScenario.js
+++ b/backend/modules/scenarios/services/duplicateScenario.js
@@ -1,5 +1,6 @@
 import omit from 'lodash/omit.js';
 import duplicateSlides from '../../slides/services/duplicateSlides.js';
+import duplicateStems from '../../stems/services/duplicateStems.js';
 import duplicateTriggers from '../../triggers/services/duplicateTriggers.js';
 import checkHasAccessToScenario from '../helpers/checkHasAccessToScenario.js';
 
@@ -44,6 +45,38 @@ export default async (props, options, context) => {
     const slideRefMap = new Map();
     for (const duplicatedSlide of duplicatedSlides) {
       slideRefMap.set(duplicatedSlide.originalRef.toString(), duplicatedSlide.ref);
+    }
+
+    // Duplicate stems and remap their hierarchy + slide associations onto the new refs
+    const duplicatedStems = await duplicateStems({ scenarioId: existingScenario._id, newScenarioId: newScenario._id }, { ...context, session });
+
+    const stemRefMap = new Map();
+    for (const duplicatedStem of duplicatedStems) {
+      stemRefMap.set(duplicatedStem.originalRef.toString(), duplicatedStem.ref);
+    }
+
+    for (const duplicatedStem of duplicatedStems) {
+      const stemUpdate = {};
+      if (duplicatedStem.stemRef) {
+        const newStemRef = stemRefMap.get(duplicatedStem.stemRef.toString());
+        if (newStemRef) stemUpdate.stemRef = newStemRef;
+      }
+      if (duplicatedStem.slideRef) {
+        const newSlideRef = slideRefMap.get(duplicatedStem.slideRef.toString());
+        if (newSlideRef) stemUpdate.slideRef = newSlideRef;
+      }
+      if (Object.keys(stemUpdate).length) {
+        await models.Stem.updateOne({ _id: duplicatedStem._id }, { $set: stemUpdate }, { session });
+      }
+    }
+
+    // Remap stemRef on duplicated slides to point to the new stems
+    for (const duplicatedSlide of duplicatedSlides) {
+      if (!duplicatedSlide.stemRef) continue;
+      const newStemRef = stemRefMap.get(duplicatedSlide.stemRef.toString());
+      if (newStemRef) {
+        await models.Slide.updateOne({ _id: duplicatedSlide._id }, { $set: { stemRef: newStemRef } }, { session });
+      }
     }
 
     const newBlocks = await models.Block.find({ scenario: newScenario._id }, null, { session });

--- a/backend/modules/stems/services/duplicateStems.js
+++ b/backend/modules/stems/services/duplicateStems.js
@@ -1,0 +1,24 @@
+import omit from 'lodash/omit.js';
+
+export default async ({ scenarioId, newScenarioId }, context) => {
+
+  const { models, session } = context;
+
+  const stems = await models.Stem.find({ scenario: scenarioId, isDeleted: false });
+
+  const duplicatedStems = [];
+
+  for (const stem of stems) {
+    const duplicatedStemObject = omit(stem, ['_id', 'ref']);
+    duplicatedStemObject.scenario = newScenarioId;
+    duplicatedStemObject.originalRef = stem.ref;
+    duplicatedStemObject.originalScenario = stem.scenario;
+    duplicatedStemObject.createdAt = new Date();
+
+    const bulkStems = await models.Stem.create([duplicatedStemObject], { session });
+    duplicatedStems.push(bulkStems[0]);
+  }
+
+  return duplicatedStems;
+
+};

--- a/backend/modules/stems/stems.schema.js
+++ b/backend/modules/stems/stems.schema.js
@@ -4,6 +4,8 @@ const schema = {
   type: { type: String, default: 'stem' },
   ref: mongoose.Schema.Types.ObjectId,
   scenario: { type: mongoose.Schema.Types.ObjectId, ref: 'Scenario', required: true },
+  originalRef: mongoose.Schema.Types.ObjectId,
+  originalScenario: { type: mongoose.Schema.Types.ObjectId, ref: 'Scenario' },
   name: { type: String, default: '' },
   description: { type: String, default: '' },
   stemRef: { type: mongoose.Schema.Types.ObjectId, ref: 'Stem' },

--- a/backend/modules/stems/tests/duplicateStems.test.js
+++ b/backend/modules/stems/tests/duplicateStems.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import duplicateStems from '../services/duplicateStems.js';
+
+const FIXED_NOW = new Date('2026-05-07T12:00:00Z');
+
+describe('duplicateStems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clones every non-deleted stem under the new scenario, stamping originalRef', async () => {
+    const stems = [
+      { _id: 'id1', ref: 'rootRef', scenario: 'sOld', name: 'Root', isRoot: true },
+      { _id: 'id2', ref: 'childRef', scenario: 'sOld', name: 'Child', stemRef: 'rootRef', slideRef: 'slideRef' }
+    ];
+
+    const find = vi.fn().mockResolvedValue(stems);
+    const create = vi.fn()
+      .mockResolvedValueOnce([{ _id: 'newId1', ref: 'newRootRef', originalRef: 'rootRef' }])
+      .mockResolvedValueOnce([{ _id: 'newId2', ref: 'newChildRef', originalRef: 'childRef' }]);
+
+    const context = {
+      models: { Stem: { find, create } },
+      session: 'SESSION_TOKEN'
+    };
+
+    const result = await duplicateStems({ scenarioId: 'sOld', newScenarioId: 'sNew' }, context);
+
+    expect(find).toHaveBeenCalledWith({ scenario: 'sOld', isDeleted: false });
+
+    const [firstArgs, firstOptions] = create.mock.calls[0];
+    expect(firstArgs[0]).toMatchObject({
+      scenario: 'sNew',
+      name: 'Root',
+      isRoot: true,
+      originalRef: 'rootRef',
+      createdAt: FIXED_NOW
+    });
+    expect(firstArgs[0]._id).toBeUndefined();
+    expect(firstArgs[0].ref).toBeUndefined();
+    expect(firstOptions).toEqual({ session: 'SESSION_TOKEN' });
+
+    const [secondArgs] = create.mock.calls[1];
+    expect(secondArgs[0]).toMatchObject({
+      scenario: 'sNew',
+      name: 'Child',
+      stemRef: 'rootRef',
+      slideRef: 'slideRef',
+      originalRef: 'childRef'
+    });
+
+    expect(result).toEqual([
+      { _id: 'newId1', ref: 'newRootRef', originalRef: 'rootRef' },
+      { _id: 'newId2', ref: 'newChildRef', originalRef: 'childRef' }
+    ]);
+  });
+});

--- a/workers/upgrades/addStemsToScenarios.js
+++ b/workers/upgrades/addStemsToScenarios.js
@@ -33,15 +33,20 @@ export default async () => {
       createdStem = true;
     }
 
+    const stems = await models.Stem.find({ scenario: scenario._id, isDeleted: false });
+    const validStemRefs = stems.map((stem) => stem.ref);
+
+    // Fix slides whose stemRef is missing or points to a stem outside this scenario
+    // (left over from a bad duplication) by pointing them at the root stem
     const result = await models.Slide.updateMany(
-      { scenario: scenario._id, stemRef: { $exists: false } },
+      { scenario: scenario._id, $or: [{ stemRef: { $exists: false } }, { stemRef: { $nin: validStemRefs } }] },
       { stemRef: rootStem.ref }
     );
 
     if (createdStem) {
-      console.log(`Scenario "${scenario.name}" — created root stem, backfilled ${result.modifiedCount} slides`);
+      console.log(`Scenario "${scenario.name}" — created root stem, fixed ${result.modifiedCount} slides`);
     } else {
-      console.log(`Scenario "${scenario.name}" — backfilled ${result.modifiedCount} slides`);
+      console.log(`Scenario "${scenario.name}" — fixed ${result.modifiedCount} slides`);
     }
 
   }

--- a/workers/upgrades/tests/addStemsToScenarios.test.js
+++ b/workers/upgrades/tests/addStemsToScenarios.test.js
@@ -14,6 +14,7 @@ import addStemsToScenarios from '../addStemsToScenarios.js';
 
 const buildModels = ({ scenarios = [], publishedScenarios = [] } = {}) => {
   const stemFindOne = vi.fn();
+  const stemFind = vi.fn().mockResolvedValue([]);
   const stemCreate = vi.fn();
   const slideUpdateMany = vi.fn().mockResolvedValue({ modifiedCount: 0 });
 
@@ -25,12 +26,13 @@ const buildModels = ({ scenarios = [], publishedScenarios = [] } = {}) => {
     models: {
       Scenario: { find: vi.fn().mockResolvedValue(scenarios) },
       Published_Scenario: { find: vi.fn().mockResolvedValue(publishedScenarios) },
-      Stem: { findOne: stemFindOne, create: stemCreate },
+      Stem: { findOne: stemFindOne, find: stemFind, create: stemCreate },
       Published_Stem: { findOne: publishedStemFindOne, create: publishedStemCreate },
       Slide: { updateMany: slideUpdateMany },
       Published_Slide: { updateMany: publishedSlideUpdateMany }
     },
     stemFindOne,
+    stemFind,
     stemCreate,
     slideUpdateMany,
     publishedStemFindOne,
@@ -42,12 +44,13 @@ const buildModels = ({ scenarios = [], publishedScenarios = [] } = {}) => {
 describe('addStemsToScenarios', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('creates a root stem and backfills slides when a scenario has no root stem', async () => {
+  it('creates a root stem and fixes slides when a scenario has no root stem', async () => {
     const setup = buildModels({
       scenarios: [{ _id: 's1', name: 'A' }]
     });
     setup.stemFindOne.mockResolvedValue(null);
     setup.stemCreate.mockResolvedValue({ _id: 'st1', ref: 'stRef1' });
+    setup.stemFind.mockResolvedValue([{ ref: 'stRef1' }]);
     setup.slideUpdateMany.mockResolvedValue({ modifiedCount: 3 });
 
     connectDatabaseMock.mockResolvedValue({ models: setup.models });
@@ -61,7 +64,7 @@ describe('addStemsToScenarios', () => {
       isRoot: true
     });
     expect(setup.slideUpdateMany).toHaveBeenCalledWith(
-      { scenario: 's1', stemRef: { $exists: false } },
+      { scenario: 's1', $or: [{ stemRef: { $exists: false } }, { stemRef: { $nin: ['stRef1'] } }] },
       { stemRef: 'stRef1' }
     );
   });
@@ -71,6 +74,7 @@ describe('addStemsToScenarios', () => {
       scenarios: [{ _id: 's1', name: 'A' }]
     });
     setup.stemFindOne.mockResolvedValue({ _id: 'existing', ref: 'existingRef' });
+    setup.stemFind.mockResolvedValue([{ ref: 'existingRef' }]);
     setup.slideUpdateMany.mockResolvedValue({ modifiedCount: 0 });
 
     connectDatabaseMock.mockResolvedValue({ models: setup.models });
@@ -79,8 +83,27 @@ describe('addStemsToScenarios', () => {
 
     expect(setup.stemCreate).not.toHaveBeenCalled();
     expect(setup.slideUpdateMany).toHaveBeenCalledWith(
-      { scenario: 's1', stemRef: { $exists: false } },
+      { scenario: 's1', $or: [{ stemRef: { $exists: false } }, { stemRef: { $nin: ['existingRef'] } }] },
       { stemRef: 'existingRef' }
+    );
+  });
+
+  it('remaps slides pointing at stems outside the scenario onto the root stem', async () => {
+    const setup = buildModels({
+      scenarios: [{ _id: 's1', name: 'A' }]
+    });
+    setup.stemFindOne.mockResolvedValue({ _id: 'root', ref: 'rootRef' });
+    setup.stemFind.mockResolvedValue([{ ref: 'rootRef' }, { ref: 'childRef' }]);
+    setup.slideUpdateMany.mockResolvedValue({ modifiedCount: 2 });
+
+    connectDatabaseMock.mockResolvedValue({ models: setup.models });
+
+    await addStemsToScenarios();
+
+    expect(setup.stemFind).toHaveBeenCalledWith({ scenario: 's1', isDeleted: false });
+    expect(setup.slideUpdateMany).toHaveBeenCalledWith(
+      { scenario: 's1', $or: [{ stemRef: { $exists: false } }, { stemRef: { $nin: ['rootRef', 'childRef'] } }] },
+      { stemRef: 'rootRef' }
     );
   });
 
@@ -117,6 +140,9 @@ describe('addStemsToScenarios', () => {
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce({ _id: 'existing', ref: 'existingRef' });
     setup.stemCreate.mockResolvedValue({ _id: 'st1', ref: 'stRef1' });
+    setup.stemFind
+      .mockResolvedValueOnce([{ ref: 'stRef1' }])
+      .mockResolvedValueOnce([{ ref: 'existingRef' }]);
 
     connectDatabaseMock.mockResolvedValue({ models: setup.models });
 
@@ -125,12 +151,12 @@ describe('addStemsToScenarios', () => {
     expect(setup.stemCreate).toHaveBeenCalledTimes(1);
     expect(setup.slideUpdateMany).toHaveBeenNthCalledWith(
       1,
-      { scenario: 's1', stemRef: { $exists: false } },
+      { scenario: 's1', $or: [{ stemRef: { $exists: false } }, { stemRef: { $nin: ['stRef1'] } }] },
       { stemRef: 'stRef1' }
     );
     expect(setup.slideUpdateMany).toHaveBeenNthCalledWith(
       2,
-      { scenario: 's2', stemRef: { $exists: false } },
+      { scenario: 's2', $or: [{ stemRef: { $exists: false } }, { stemRef: { $nin: ['existingRef'] } }] },
       { stemRef: 'existingRef' }
     );
   });


### PR DESCRIPTION
Scenario duplication never cloned stems, so duplicated slides kept stemRef values pointing at the original scenario's stems.

- Add duplicateStems service and wire it into duplicateScenario, remapping stem hierarchy, stem slideRef, and slide stemRef onto the new refs
- Add originalRef/originalScenario to the stem schema
- Extend addStemsToScenarios upgrade to repair already-duplicated scenarios by pointing orphaned slide stemRefs at the root stem